### PR TITLE
Setting Snipcart language

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -54,6 +54,10 @@ const StyledMain = styled.main`
   padding: 50px 50px 0 50px;
 `
 
+document.addEventListener('snipcart.ready', () => {
+  window.Snipcart.setLang('nl');
+});
+
 const Layout = ({ children, location }) => (
   <StaticQuery
     query={graphql`


### PR DESCRIPTION
I used Snipcart's JavaScript API to set language when mounting the application. This should be preferred over the `lang` attribute in the case of a JavaScript application like this.